### PR TITLE
fix spelling errors

### DIFF
--- a/src/renderer/src/pages/connections.tsx
+++ b/src/renderer/src/pages/connections.tsx
@@ -103,7 +103,7 @@ const Connections: React.FC = () => {
         const uploadSpeed = preConn ? conn.upload - preConn.upload : 0
         const metadata = {
           ...conn.metadata,
-          ...((!conn.metadata.sourceIP) && { process: 'mohomo' })
+          ...((!conn.metadata.sourceIP) && { process: 'mihomo' })
         }
         return {
           ...conn,


### PR DESCRIPTION
我想这里是拼写错误？  
当某条连接没有 sourceIP 时，界面上会默认展示 “m **o** homo” 而不是预期的 “m **i** homo”