### PR TITLE
fix macOS pkg postinstall signing guard

### DIFF
--- a/build/pkg-scripts/postinstall
+++ b/build/pkg-scripts/postinstall
@@ -1,17 +1,67 @@
 #!/bin/sh
 
-APP_PATH="/Applications/Sparkle.app"
+set -eu
 
-chown root:admin "$APP_PATH/Contents/Resources/sidecar/mihomo"
-chown root:admin "$APP_PATH/Contents/Resources/sidecar/mihomo-alpha"
-chmod +s "$APP_PATH/Contents/Resources/sidecar/mihomo"
-chmod +s "$APP_PATH/Contents/Resources/sidecar/mihomo-alpha"
+fail() {
+  echo "Sparkle postinstall: $*" >&2
+  exit 1
+}
 
-/usr/bin/codesign --force --deep --sign - "$APP_PATH"
+find_app_path() {
+  INSTALL_TARGET="${1:-}"
+
+  if [ -n "$INSTALL_TARGET" ] && [ -d "$INSTALL_TARGET/Contents" ]; then
+    printf '%s\n' "$INSTALL_TARGET"
+    return 0
+  fi
+
+  if [ -n "$INSTALL_TARGET" ] && [ -d "$INSTALL_TARGET/Sparkle.app/Contents" ]; then
+    printf '%s\n' "$INSTALL_TARGET/Sparkle.app"
+    return 0
+  fi
+
+  if [ -d "/Applications/Sparkle.app/Contents" ]; then
+    printf '%s\n' "/Applications/Sparkle.app"
+    return 0
+  fi
+
+  return 1
+}
+
+APP_PATH="$(find_app_path "${2:-}")" || fail "could not find installed Sparkle.app"
+SERVICE_BIN="$APP_PATH/Contents/Resources/files/sparkle-service"
+SERVICE_STATE_FILE="/tmp/sparkle-service-was-running"
+
+apply_sidecar_permissions() {
+  for BIN in "$APP_PATH/Contents/Resources/sidecar/mihomo" \
+             "$APP_PATH/Contents/Resources/sidecar/mihomo-alpha"; do
+    [ -e "$BIN" ] || fail "missing sidecar binary: $BIN"
+    chown root:admin "$BIN" || fail "failed to chown $BIN"
+    chmod +s "$BIN" || fail "failed to set setuid bit on $BIN"
+  done
+}
+
+sign_app_bundle() {
+  [ -e "$APP_PATH/Contents/MacOS/Sparkle" ] || fail "missing app executable"
+
+  # Do not preserve hardened-runtime flags for the ad-hoc postinstall signature:
+  # ad-hoc + runtime can make dyld reject Electron Framework at launch.
+  /usr/bin/codesign --force --deep --sign - "$APP_PATH" || fail "codesign failed"
+}
+
+verify_postinstall_signature() {
+  SIGN_INFO="$(/usr/bin/codesign -dv --verbose=4 "$APP_PATH" 2>&1 || true)"
+  TEAM_ID="$(printf '%s\n' "$SIGN_INFO" | sed -n 's/^TeamIdentifier=//p' | head -n 1)"
+  FLAGS="$(printf '%s\n' "$SIGN_INFO" | sed -n 's/.*flags=[^)]*(\([^)]*\)).*/\1/p' | head -n 1)"
+
+  if [ "$TEAM_ID" = "not set" ] && printf '%s' "$FLAGS" | grep -q 'runtime'; then
+    fail "ad-hoc signature still has hardened runtime; Electron Framework may fail library validation"
+  fi
+
+  /usr/bin/codesign --verify --deep --strict "$APP_PATH" || fail "codesign verification failed"
+}
 
 restore_sparkle_service_if_was_running() {
-  SERVICE_BIN="$APP_PATH/Contents/Resources/files/sparkle-service"
-  SERVICE_STATE_FILE="/tmp/sparkle-service-was-running"
 
   if [ ! -f "$SERVICE_STATE_FILE" ]; then
     return
@@ -23,6 +73,9 @@ restore_sparkle_service_if_was_running() {
   fi
 }
 
+apply_sidecar_permissions
+sign_app_bundle
+verify_postinstall_signature
 restore_sparkle_service_if_was_running
 
 exit 0


### PR DESCRIPTION
## Summary

- make macOS `postinstall` resolve the installed Sparkle.app whether Installer passes `/Applications` or `/Applications/Sparkle.app`
- keep the manual recovery command as the scripted behavior: deep ad-hoc sign the app after `chown`/`chmod +s`
- fail postinstall if the resulting ad-hoc signature still keeps hardened runtime flags, because that can make dyld reject Electron Framework at launch
- run `codesign --verify --deep --strict` after signing so a broken package fails during install instead of opening to a crash later

Fixes #212
Related #194

## Local evidence

On a macOS 26.4.1 arm64 machine, the 1.26.4 arm64 pkg installed an app with:

```text
flags=adhoc,runtime
TeamIdentifier=not set
```

Launching failed with:

```text
Library not loaded: @rpath/Electron Framework.framework/Electron Framework
Reason: ... not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs
```

Running the documented recovery command changed the installed app to:

```text
flags=adhoc
TeamIdentifier=not set
```

and the app launched successfully.

## Tests

```text
sh -n build/pkg-scripts/postinstall
sh -n build/pkg-scripts/preinstall
git diff --check
codesign --verify --deep --strict /Applications/Sparkle.app
```

Also checked the signature parser against the 1.26.4 pkg payload and a manually re-signed app:

```text
pkg payload: flags=adhoc,runtime, TeamIdentifier=not set
re-signed app: flags=adhoc, TeamIdentifier=not set
```